### PR TITLE
Remove bolding stars from places where they don't mean "bold"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "osumo",
   "version": "0.0.1",
-  "description": "**M**ulti-**O**mics Data Analytics @ **OSU**",
+  "description": "Multi-Omics Data Analytics @ OSU",
   "repository": "git://github.com/osumo/osumo.git",
   "license": "Apache-2.0",
   "dependencies": {

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 
 name: OSUMO
 version: 0.0.1
-description: "**M**ulti-**O**mics Data Analytics @ **OSU**"
+description: "Multi-Omics Data Analytics @ OSU"
 grunt:
     autobuild: false
     dependencies:


### PR DESCRIPTION
Seems silly maybe but the stars show up as literal stars in, e.g., the Girder plugin control panel, where at a quick glance they look like a censored curse word or something. This just makes the text more readable in the places where the stars would otherwise show up as stars.
