### PR TITLE
fix build issue with latest babel-runtime package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-runtime": "^6.5.0",
+    "babel-runtime": "^5.0.0",
     "backbone": "^1.2.3",
     "bluebird": "^3.2.2",
     "bootstrap": "^3.3.6",


### PR DESCRIPTION
for some reason I don't entirely understand, I've had to downgrade dependencies in the package.json file to get things deployed without problems.  This PR merges the changes to master so that I can bring all submodules up to date in `osumo-project`.
