### PR TITLE
fix an issue with compose creating problematic reducers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ script:
 
   - python -m girder_worker >/tmp/worker.out 2>&1 &
   - cd $main_path
+  - npm run 'test:frontend'
   - mkdir -p _build
   - cd _build
   # Our coverage numbers are small, because we aren't testing all of girder

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,14 +98,16 @@ install:
   - npm install
 
 script:
-  - cd $girder_worker_path
-
   - echo $R_LIBS
   - R -e ".libPaths()"
 
-  - python -m girder_worker >/tmp/worker.out 2>&1 &
   - cd $main_path
   - npm run 'test:frontend'
+
+  - cd $girder_worker_path
+  - python -m girder_worker >/tmp/worker.out 2>&1 &
+
+  - cd $main_path
   - mkdir -p _build
   - cd _build
   # Our coverage numbers are small, because we aren't testing all of girder

--- a/package.json
+++ b/package.json
@@ -35,6 +35,13 @@
   },
   "scripts": {
     "build": "webpack",
-    "build:watch": "webpack --watch --progress"
+    "build:watch": "webpack --watch --progress",
+    "test:frontend": "node_modules/.bin/babel-tape-runner 'web-external/tests/**/*.js*' | node_modules/.bin/tap-spec"
+  },
+  "devDependencies": {
+    "babel-plugin-transform-react-jsx": "^6.8.0",
+    "babel-tape-runner": "^2.0.1",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "webpack",
     "build:watch": "webpack --watch --progress",
-    "test:frontend": "node_modules/.bin/babel-tape-runner 'web-external/tests/**/*.js*' | node_modules/.bin/tap-spec"
+    "test:frontend": "babel-tape-runner 'web-external/tests/**/*.js*' | tap-spec"
   },
   "devDependencies": {
     "babel-plugin-transform-react-jsx": "^6.8.0",

--- a/web-external/.babelrc
+++ b/web-external/.babelrc
@@ -1,0 +1,4 @@
+{
+  "plugins": ["transform-runtime", "transform-react-jsx"],
+  "presets": ["es2015", "stage-0", "react"]
+}

--- a/web-external/tests/compose.js
+++ b/web-external/tests/compose.js
@@ -1,0 +1,79 @@
+
+import { createStore } from 'redux';
+import { compose } from '../src/utils/reducer';
+import { setScalar } from '../src/utils/common-reducers';
+
+import test from 'tape';
+
+
+test('compose duplicate leaves', (t) => {
+  t.plan(20);
+
+  const scalar = (def) => compose({ set: setScalar }).defaultState(def);
+
+  const a  = scalar('a');
+  const b  = scalar('b');
+  const ca = scalar('ca');
+  const cb = scalar('CB');
+
+  const c = compose({
+    'b.set': (state, action) => {
+      let newAction = {
+        ...action,
+        type: cb().set,
+        value: action.value.toUpperCase()
+      };
+
+      let newB = cb(state.b, newAction);
+      let newState = state;
+      if(newB !== state.b) {
+        newState = {
+          ...state,
+          b: newB
+        };
+      }
+
+      return newState;
+    }
+  }).children({a: ca, b: cb});
+
+  const reducer = compose().children({a, b, c});
+  const store = createStore(reducer);
+  const actionTypes = reducer();
+
+  let state = store.getState();
+  t.equal(state.a, 'a');
+  t.equal(state.b, 'b');
+  t.equal(state.c.a, 'ca');
+  t.equal(state.c.b, 'CB');
+
+  store.dispatch({ type: actionTypes.a.set, value: "aa" });
+  state = store.getState();
+  t.equal(state.a, 'aa');
+  t.equal(state.b, 'b');
+  t.equal(state.c.a, 'ca');
+  t.equal(state.c.b, 'CB');
+
+  store.dispatch({ type: actionTypes.b.set, value: "bb" });
+  state = store.getState();
+  t.equal(state.a, 'aa');
+  t.equal(state.b, 'bb');
+  t.equal(state.c.a, 'ca');
+  t.equal(state.c.b, 'CB');
+
+  store.dispatch({ type: actionTypes.c.a.set, value: "caca" });
+  state = store.getState();
+  t.equal(state.a, 'aa');
+  t.equal(state.b, 'bb');
+  t.equal(state.c.a, 'caca');
+  t.equal(state.c.b, 'CB');
+
+  store.dispatch({ type: actionTypes.c.b.set, value: "cbcb" });
+  state = store.getState();
+  t.equal(state.a, 'aa');
+  t.equal(state.b, 'bb');
+  t.equal(state.c.a, 'caca');
+  t.equal(state.c.b, 'CBCB');
+});
+
+

--- a/web-external/tests/compose.js
+++ b/web-external/tests/compose.js
@@ -1,14 +1,9 @@
-
 import { createStore } from 'redux';
 import { compose } from '../src/utils/reducer';
 import { setScalar } from '../src/utils/common-reducers';
-
 import test from 'tape';
 
-
 test('compose duplicate leaves', (t) => {
-  t.plan(20);
-
   const scalar = (def) => compose({ set: setScalar }).defaultState(def);
 
   const a  = scalar('a');
@@ -74,6 +69,6 @@ test('compose duplicate leaves', (t) => {
   t.equal(state.b, 'bb');
   t.equal(state.c.a, 'caca');
   t.equal(state.c.b, 'CBCB');
+
+  t.end();
 });
-
-


### PR DESCRIPTION
- Fixes an issue where reducers created using `compose()` would always delegate
  to reducers that were meant to respond to action types that had the same
  tail name.  For example, consider the following state tree:

```
{
    a: {
        setValue ...
        clearValue ...
    },

    b: {
        setValue ...
        clearValue ...
    },

    c: {
        a: { setValue ...  },
        b: { setValue ...  }
    }
}
```

Actions dispatched that end with "setValue" would propogate to all reducers, and all the "setValue" reducers would react to the action.  In other words:

```
    store.dispatch({ type: reducer().a.setValue, value: 2 })
```

... would set state.a, state.b, state.c.a, and state.c.b all to 2.  The intended behavior was to only set state.a to 2.
- Also adds some basic unit testing for front-end code.
