### PR TITLE
On travis build failures, show the worker log.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ cache:
   pip: true
   directories:
     - $HOME/.cache
-    - $HOME/build/osumo/osumo/_build/data/plugins/osumo
+    - $HOME/build/osumo/osumo/_build/store
+    - $HOME/build/osumo/osumo/_build/data
 sudo: false
 
 compiler:
@@ -41,7 +42,8 @@ before_install:
   - mkdir -p $build_path
 
   - mkdir -p $HOME/.cache
-  - mkdir -p $HOME/build/osumo/osumo/_build/data/plugins/osumo
+  - mkdir -p $HOME/build/osumo/osumo/_build/data
+  - mkdir -p $HOME/build/osumo/osumo/_build/store
 
   - export R_LIBS=$HOME/.cache/R
   - export R_LIBS_USER=$R_LIBS
@@ -90,8 +92,21 @@ before_install:
   - ln -s $main_path $girder_path/plugins/osumo
 
 install:
-  - R -e "install.packages(c('colorspace', 'deldir', 'FNN', 'magrittr', 'proxy', 'RColorBrewer'), repos='http://cran.rstudio.com')"
-  - R -e "install.packages(c('cccd', 'cluster', 'igraph', 'jsonlite', 'pheatmap', 'survival'), repos='http://cran.rstudio.com')"
+  # Only install R packages if they aren't present or are older versions than 
+  # we expect.  Without the conditional installation, caching the packages in
+  # Travis doesn't same much time.  We just use one package for each set for
+  # version comparison, as this should be sufficient for cache purposes.
+
+  - R -e "if (require('colorspace')) packageVersion('colorspace')"
+  - R -e "if (!require('colorspace') || packageVersion('colorspace') < numeric_version('1.2.6')) install.packages(c('colorspace', 'deldir', 'FNN', 'magrittr', 'proxy', 'RColorBrewer'), repos='http://cran.rstudio.com')"
+  # - R -e "install.packages(c('colorspace', 'deldir', 'FNN', 'magrittr', 'proxy', 'RColorBrewer'), repos='http://cran.rstudio.com')"
+  - R -e "packageVersion('colorspace')"
+
+  - R -e "if (require('cccd')) packageVersion('cccd')"
+  # - R -e "install.packages(c('cccd', 'cluster', 'igraph', 'jsonlite', 'pheatmap', 'survival'), repos='http://cran.rstudio.com')"
+  - R -e "if (!require('cccd') || packageVersion('cccd') < numeric_version('1.5')) install.packages(c('cccd', 'cluster', 'igraph', 'jsonlite', 'pheatmap', 'survival'), repos='http://cran.rstudio.com')"
+  - R -e "packageVersion('cccd')"
+
   - cd $girder_path
   - pip install -U -r requirements.txt -r requirements-dev.txt
   # - pip install --no-cache-dir -e .
@@ -113,6 +128,8 @@ script:
   # Enable to verify worker is running
   # - cat /tmp/worker.out
   - JASMINE_TIMEOUT=15000 ctest -VV -R '(py_coverage_reset|py_coverage_combine|py_coverage$|coverage_xml|osumo)'
-  # Enable to see worker log output
-  # - cat /tmp/worker.out
+
+after_failure:
+  # On failures, show girder's error long and the worker output
+  - cat /tmp/worker.out
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ before_install:
 install:
   # Only install R packages if they aren't present or are older versions than 
   # we expect.  Without the conditional installation, caching the packages in
-  # Travis doesn't same much time.  We just use one package for each set for
+  # Travis doesn't save much time.  We just use one package for each set for
   # version comparison, as this should be sufficient for cache purposes.
 
   - R -e "if (require('colorspace')) packageVersion('colorspace')"
@@ -130,6 +130,6 @@ script:
   - JASMINE_TIMEOUT=15000 ctest -VV -R '(py_coverage_reset|py_coverage_combine|py_coverage$|coverage_xml|osumo)'
 
 after_failure:
-  # On failures, show girder's error long and the worker output
+  # On failures, show girder's error log and the worker output
   - cat /tmp/worker.out
 

--- a/plugin_tests/tasks_test.py
+++ b/plugin_tests/tasks_test.py
@@ -148,7 +148,7 @@ class OsumoTasksTest(base.TestCase):
             }
         return files
 
-    def _processTask(self, params, result=None, timeout=10):
+    def _processTask(self, params, result=None, timeout=30):
         """
         Run an OSUMO task until it ends.
 
@@ -180,10 +180,13 @@ class OsumoTasksTest(base.TestCase):
                                 params={'token': jobToken})
             self.assertStatusOk(resp)
             job = resp.json
-            if job['status'] in (
-                    girder.plugins.jobs.constants.JobStatus.ERROR,
-                    girder.plugins.jobs.constants.JobStatus.CANCELED,
-                    girder.plugins.jobs.constants.JobStatus.SUCCESS):
+            # Ensure that there is something in the job log if we had an error,
+            # as that gets flushed after the status change
+            if ((job.get('log') and job['status'] in (
+                    girder.plugins.jobs.constants.JobStatus.ERROR, )) or
+                    job['status'] in (
+                        girder.plugins.jobs.constants.JobStatus.CANCELED,
+                        girder.plugins.jobs.constants.JobStatus.SUCCESS)):
                 self.assertEqual(job['status'], result)
                 return job
             time.sleep(0.05)
@@ -366,4 +369,3 @@ class OsumoTasksTest(base.TestCase):
                             isJson=False)
         results = self.getBody(resp, text=False)
         self.assertEqual(results[:4], '\x89PNG')
-        # ##DWM::


### PR DESCRIPTION
Do a better job of caching R packages and downloaded test files in travis.

Increase the job processing time-out.  Wait for a job log message when errors occur, as those get flushed after the status update.

This fixes an intermittent test error caused by the asynchronous nature of job logs.  It should make future intermittent errors easier to debug.
