### PR TITLE
Move linting to npm script instead of webpack preloader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,8 @@ script:
   - echo $R_LIBS
   - R -e ".libPaths()"
 
+  - npm run lint
+
   - cd $main_path
   - npm run 'test:frontend'
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.0",
     "redux": "^3.3.1",
-    "semistandard-loader": "0.0.3",
     "style-loader": "^0.13.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^2.0.0",
@@ -42,6 +41,7 @@
   "devDependencies": {
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-tape-runner": "^2.0.1",
+    "semistandard": "^9.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "webpack",
     "build:watch": "webpack --watch --progress",
+    "lint": "semistandard web-external/src",
     "test:frontend": "babel-tape-runner 'web-external/tests/**/*.js*' | tap-spec"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,14 +91,6 @@ module.exports = {
     },
 
     module: {
-        preLoaders: [
-          {
-            test: /\.js[x]$/,
-            loader: 'semistandard',
-            include: path.resolve(__dirname, 'web-external', 'src')
-          }
-        ],
-
         loaders: [
             { test: /\.css$/,
               loader: "style-loader!css-loader" },


### PR DESCRIPTION
I've recently been unable to use `semistandard-loader` in my NPM projects. I think it might have to do with API breakage between Node 5.x and 6.x but I'm not sure.
