### PR TITLE
Fix select option defaults.

### DIFF
--- a/web-external/src/components/body/process-data.jsx
+++ b/web-external/src/components/body/process-data.jsx
@@ -146,6 +146,15 @@ class ProcessDataComponent extends React.Component {
       this.setState({inputs: inputs});
     };
 
+    /* Update the default that will be applied if nothing is changed.
+     *
+     * @param {string} key input key
+     * @param {string} value default value
+     */
+    this.setInputDefault = (key, value) => {
+      this.inputDefaults[key] = value;
+    };
+
     /* Run a task.
      *
      * @param {number} position if set, this is the chained process position.
@@ -444,12 +453,12 @@ class ProcessDataComponent extends React.Component {
               className='form-control'
               onChange={this.changeTaskInput}
               onSetItem={partial(this.setTaskInput, inpspec.key)}
+              onSetDefault={partial(this.setInputDefault, inpspec.key)}
               selected={input}
               options={items}
               inpspec={inpspecCopy}
               folder={this.dataFolder} />
           );
-          defaultValue = items[0]._id;
           break;
         case 'boolean':
           ctl.push(<input type='checkbox' className='form-control'

--- a/web-external/src/components/common/select.jsx
+++ b/web-external/src/components/common/select.jsx
@@ -8,7 +8,9 @@ export default class Select extends React.Component {
     const {
       inpspec,
       folder,
-      options
+      options,
+      onSetDefault,
+      selected
     } = this.props;
 
     if (inpspec.onlyNames || inpspec.preferredNames) {
@@ -41,6 +43,10 @@ export default class Select extends React.Component {
                  value='Add a file'/>
         </div>
       );
+    }
+
+    if (selected === undefined) {
+      onSetDefault(options.find(item => !inpspec.onlyNames || item.matched)._id);
     }
 
     this.setState({options});


### PR DESCRIPTION
Before, the default item was the zeroth entry before sorting, even if it wasn't shown (or didn't exist).