### PR TITLE
remove extra parts in the file-selector dialog

### DIFF
--- a/web-external/src/components/dialog/file-selector/body.jsx
+++ b/web-external/src/components/dialog/file-selector/body.jsx
@@ -5,11 +5,14 @@ import { setFileNavigation } from '../../../actions';
 import RootSelector from '../../common/root-selector';
 
 /* hacked to remove the download and view links */
-/* TODO(opadron): flags controlling these links should be upstreamed */
+/* TODO(opadron): replace this with flags from girder/girder#1688 once we
+ * migrate to Girder 2.0 */
 import customItemListTemplate from './item-list-template';
 girder.templates.itemList = customItemListTemplate;
 
 /* hacked to remove the metadata section */
+/* TODO(opadron): replace this with flags from girder/girder#1688 once we
+ * migrate to Girder 2.0 */
 import customHierarchyTemplate from './hierarchy-template.jade';
 girder.templates.hierarchyWidget = customHierarchyTemplate;
 

--- a/web-external/src/components/dialog/file-selector/body.jsx
+++ b/web-external/src/components/dialog/file-selector/body.jsx
@@ -1,18 +1,25 @@
 import React from 'react';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import { setFileNavigation } from '../../../actions';
-
 import RootSelector from '../../common/root-selector';
+
+/* hacked to remove the download and view links */
+/* TODO(opadron): flags controlling these links should be upstreamed */
+import customItemListTemplate from './item-list-template';
+girder.templates.itemList = customItemListTemplate;
+
+// const FileSelectorView = girder.View.extend({
+console.log(girder.views.HierarchyWidget);
 
 const FileSelectorView = girder.View.extend({
   initialize: function (settings) {
     this.hierarchyView = new girder.views.HierarchyWidget({
       parentView: this,
       parentModel: settings.folder,
-      showActions: true,
+      showActions: false,
       showItems: true,
-      checkboxes: true,
+      checkboxes: false,
       routing: false,
       onItemClick: function (item) {
         settings.itemSelected(item.attributes);

--- a/web-external/src/components/dialog/file-selector/body.jsx
+++ b/web-external/src/components/dialog/file-selector/body.jsx
@@ -9,6 +9,10 @@ import RootSelector from '../../common/root-selector';
 import customItemListTemplate from './item-list-template';
 girder.templates.itemList = customItemListTemplate;
 
+/* hacked to remove the metadata section */
+import customHierarchyTemplate from './hierarchy-template.jade';
+girder.templates.hierarchyWidget = customHierarchyTemplate;
+
 // const FileSelectorView = girder.View.extend({
 console.log(girder.views.HierarchyWidget);
 

--- a/web-external/src/components/dialog/file-selector/body.jsx
+++ b/web-external/src/components/dialog/file-selector/body.jsx
@@ -13,9 +13,6 @@ girder.templates.itemList = customItemListTemplate;
 import customHierarchyTemplate from './hierarchy-template.jade';
 girder.templates.hierarchyWidget = customHierarchyTemplate;
 
-// const FileSelectorView = girder.View.extend({
-console.log(girder.views.HierarchyWidget);
-
 const FileSelectorView = girder.View.extend({
   initialize: function (settings) {
     this.hierarchyView = new girder.views.HierarchyWidget({

--- a/web-external/src/components/dialog/file-selector/hierarchy-template.jade
+++ b/web-external/src/components/dialog/file-selector/hierarchy-template.jade
@@ -1,0 +1,83 @@
+.g-hierarchy-widget
+  .g-hierarchy-breadcrumb-bar
+    ol.breadcrumb
+  if showActions
+    .g-hierarchy-actions-header
+      if checkboxes
+        input.g-select-all(type="checkbox", data-toggle="tooltip",
+                           title="Select / Unselect all")
+
+        .btn-group
+          button.g-checked-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
+            data-toggle="dropdown", disabled="disabled", title="Checked actions")
+            i.icon-check
+            i.icon-down-dir
+          ul.g-checked-actions-menu.dropdown-menu(role="menu")
+
+      .g-folder-header-buttons
+        if (type === 'folder')
+          button.g-folder-info-button.btn.btn-sm.btn-info(title="Show folder info")
+            i.icon-info
+          if (level >= AccessType.WRITE)
+            button.g-upload-here-button.btn.btn-sm.btn-success(title="Upload here")
+              i.icon-upload
+          if (level >= AccessType.ADMIN)
+            button.g-folder-access-button.g-edit-access.btn.btn-sm.btn-warning(title="Access control")
+              i.icon-lock
+        else if (type === 'collection')
+          button.g-collection-info-button.btn.btn-sm.btn-info(title="Show collection info")
+            i.icon-info
+          if (level >= AccessType.ADMIN)
+            button.g-edit-access.btn.btn-sm.btn-warning(title="Access control")
+              i.icon-lock
+        .btn-group
+          button.g-folder-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
+              data-toggle="dropdown" title="#{girder.capitalize(type)} actions", placement="left")
+            if type === 'collection'
+              i.icon-sitemap
+            else if type === 'user'
+              i.icon-user
+            else if type === 'folder'
+              i.icon-folder-open
+            i.icon-down-dir
+          ul.g-folder-actions-menu.dropdown-menu.pull-right(role="menu")
+            li.dropdown-header(role="presentation")
+              if type === 'collection'
+                i.icon-sitemap
+              else if type === 'user'
+                i.icon-user
+              else if type === 'folder'
+                i.icon-folder-open
+              |  #{model.name()}
+            if type === 'folder' || type === 'collection'
+              li(role="presentation")
+                a.g-download-folder(role="menuitem", href=model.downloadUrl())
+                  i.icon-download
+                  | Download #{type}
+            if level >= AccessType.WRITE
+              li(role="presentation")
+                a.g-create-subfolder(role="menuitem")
+                  i.icon-folder
+                  | Create folder here
+              if type === 'folder' || type === 'collection'
+                if type === 'folder'
+                  li(role="presentation")
+                    a.g-create-item(role="menuitem")
+                      i.icon-doc
+                      | Create item here
+                li(role="presentation")
+                  a.g-edit-folder(role="menuitem")
+                    i.icon-edit
+                    | Edit #{type}
+            if level >= AccessType.ADMIN && (type === 'folder' || type === 'collection')
+              li.divider(role="presentation")
+              li(role="presentation")
+                a.g-delete-folder(role="menuitem")
+                  i.icon-trash
+                  | Delete this #{type}
+      .g-clear-right
+  .g-folder-list-container
+  .g-item-list-container
+  .g-empty-parent-message.g-info-message-container.hide
+    i.icon-info-circled
+    |  This folder is empty.

--- a/web-external/src/components/dialog/file-selector/item-list-template.jade
+++ b/web-external/src/components/dialog/file-selector/item-list-template.jade
@@ -1,0 +1,14 @@
+ul.g-item-list
+  each item in items
+    li.g-item-list-entry
+      if checkboxes
+        input.g-list-checkbox(type="checkbox", g-item-cid="#{item.cid}")
+      a.g-item-list-link(g-item-cid="#{item.cid}")
+        i.icon-doc-text-inv
+        | #{item.get('name')}
+      .g-item-size #{girder.formatSize(item.get('size'))}
+  if (hasMore)
+    li.g-show-more
+      a.g-show-more-items
+        i.icon-level-down
+        | Show more items...


### PR DESCRIPTION
@manthey alerted me to some issues with the file-selector dialog that stem from the fact that a lot of extra girder widgetry was not being suppressed.  This PR should address the issues by removing these pieces with the side benefit of simplifying the dialog.  The solutions for these pieces include a combination of changing the options passed, and hacking in a custom pug template.