### PR TITLE
add link to girder ui/fix file-selection template

### DIFF
--- a/web-external/src/components/containers/header.jsx
+++ b/web-external/src/components/containers/header.jsx
@@ -12,8 +12,8 @@ const HeaderContainer = connect(
 
   (dispatch) => ({
     onDropdown: actions.toggleHeaderDropdown,
-    onFolders: (id) => router(`user/${id}`),
-    onInfo: (id) => router(`useraccount/${id}/info`),
+    onFolders: (id) => window.open(`girder#user/${ id }`, '_blank'),
+    onInfo: (id) => window.open(`girder#useraccount/${ id }/info`, '_blank'),
     onLogin: () => router('login'),
     onLogout: actions.submitLogoutForm,
     onRegister: () => router('register'),

--- a/web-external/src/components/dialog/file-selector/body.jsx
+++ b/web-external/src/components/dialog/file-selector/body.jsx
@@ -95,8 +95,20 @@ export default class Body extends React.Component {
   }
 
   render () {
+    let { folder, parentType } = this.props;
+    let manageLink = [];
+    if (folder) {
+      const manageHref = `girder#${ parentType }/${ folder._id }`;
+      const manageText = (
+        `Manage this ${ parentType }${ '\'' }s data (opens a new window)`);
+
+      manageLink.push(
+        <a href={ manageHref } key='manage' target='_blank'>{ manageText }</a>);
+    }
+
     return (
       <div className='modal-body'>
+        { manageLink }
         <div className='g-hierarchy-root-container'>
           <RootSelector onRootSelect={
             ({ id, type }) => setFileNavigation(type, id)

--- a/web-external/src/components/dialog/file-selector/hierarchy-template.jade
+++ b/web-external/src/components/dialog/file-selector/hierarchy-template.jade
@@ -32,7 +32,7 @@
               i.icon-lock
         .btn-group
           button.g-folder-actions-button.btn.btn-sm.btn-default.dropdown-toggle(
-              data-toggle="dropdown" title="#{girder.capitalize(type)} actions", placement="left")
+              data-toggle="dropdown" title=`${ girder.capitalize(type) } actions`, placement="left")
             if type === 'collection'
               i.icon-sitemap
             else if type === 'user'

--- a/web-external/src/components/dialog/file-selector/item-list-template.jade
+++ b/web-external/src/components/dialog/file-selector/item-list-template.jade
@@ -2,8 +2,8 @@ ul.g-item-list
   each item in items
     li.g-item-list-entry
       if checkboxes
-        input.g-list-checkbox(type="checkbox", g-item-cid="#{item.cid}")
-      a.g-item-list-link(g-item-cid="#{item.cid}")
+        input.g-list-checkbox(type="checkbox", g-item-cid=`${ item.cid }`)
+      a.g-item-list-link(g-item-cid=`${ item.cid }`)
         i.icon-doc-text-inv
         | #{item.get('name')}
       .g-item-size #{girder.formatSize(item.get('size'))}


### PR DESCRIPTION
Adds the go-to-Girder link.  Also, backports a fix
to an issue I discovered with the temporary
template hacks that are due to imcompatibilities
with the latest version of pug.

 - Added a link above the root selection dropdown
   that will forward users to the Girder UI, from
   which they may manage their files.

 - Added Pug 2.0 fix to the temporary template
   hacks.