### PR TITLE
provide better job results for osumo/results/:id endpoint

### DIFF
--- a/server/models/jobpayload.py
+++ b/server/models/jobpayload.py
@@ -1,0 +1,40 @@
+
+from girder.models.model_base import AccessControlledModel, ValidationException
+from girder.constants import AccessType
+
+class Jobpayload(AccessControlledModel):
+    def initialize(self):
+        self.name = 'jobpayload'
+        self.ensureIndices(('_jobId', '_userId'))
+
+    def createJobpayload(self, jobId, userId, data=None):
+        jobpayload = {
+            '_jobId': jobId,
+            '_userId': userId,
+        }
+
+        if data is not None:
+            jobpayload.update(data)
+
+        return self.save(jobpayload)
+
+    def validate(self, doc):
+        for modelType, key in (
+                (('job', 'jobs'), '_jobId'),
+                (('user',), '_userId')):
+
+            childId = doc.get(key)
+
+            if not childId:
+                raise ValidationException(
+                        'Jobpayload {} must not be empty.'.format(key), key)
+
+            childDoc = self.model(*modelType).findOne(
+                    {'_id': childId}, fields=['_id'])
+
+            if not childDoc:
+                raise ValidationException(
+                        ('Jobpayload referenced {} not found: {}.'
+                            .format(modelType[0], childId)), key)
+
+        return doc

--- a/server/task_specs/iGPSe.r
+++ b/server/task_specs/iGPSe.r
@@ -111,3 +111,8 @@ clustersJSON <- toJSON(clusters)
 # job along with the user selections from the parallel sets.
 transferData = list("clusters"=list("cl1"=mRNACluster.cl, "cl2"=miRNACluster.cl, "combine"=clusters), "mRNACluster"=mRNACluster.cl, "miRNACluster"=miRNACluster.cl, "clinical"=clinical.m)
 transferData = rawToChar(serialize(transferData, NULL, ascii=TRUE))
+
+output_mrna_dim <- toJSON(output_mrna_dim)
+output_mirna_dim <- toJSON(output_mirna_dim)
+output_clinical_dim <- toJSON(output_clinical_dim)
+

--- a/server/task_specs/iGPSe.yml
+++ b/server/task_specs/iGPSe.yml
@@ -29,18 +29,18 @@ inputs:
 outputs:
   - name: output_mrna_dim
     target: memory
-    type: r
-    format: object
+    type: string
+    format: text
 
   - name: output_mirna_dim
     target: memory
-    type: r
-    format: object
+    type: string
+    format: text
 
   - name: output_clinical_dim
     target: memory
-    type: r
-    format: object
+    type: string
+    format: text
 
   - name: output_mrna_heatmap
     target: filepath
@@ -61,3 +61,4 @@ outputs:
     target: memory
     type: string
     format: text
+

--- a/web_client/analysis-modules/igpse.jsx
+++ b/web_client/analysis-modules/igpse.jsx
@@ -33,7 +33,7 @@ const actionProcess = (data, page) => {
     mirna_clusters: `INTEGER:${state.mirna_clusters}`
   };
   const outputs = {
-    clustersJSON: `FILE:${state.output_dir}:clusters.json`,
+    clustersJSON: 'JSON',
     transferData: `FILE:${state.output_dir}:transfer-data.RData`,
     output_mrna_heatmap: `FILE:${state.output_dir}:mrna_heatmap.png`,
     output_mirna_heatmap: `FILE:${state.output_dir}:mirna_heatmap.png`
@@ -44,33 +44,22 @@ const actionProcess = (data, page) => {
   const runPromise = (
     analysisUtils.runTask(task, { inputs, outputs }, { title, maxPolls })
 
-    .then((files) => {
-      let mRNAFileId;
-      let miRNAFileId;
-      let clustersId;
-      let transferDataId;
-
-      files.forEach(({ fileId: fid, name }) => {
-        if (name === 'mrna_heatmap.png') { mRNAFileId = fid; }
-        if (name === 'mirna_heatmap.png') { miRNAFileId = fid; }
-        if (name === 'clusters.json') { clustersId = fid; }
-        if (name === 'transfer-data.RData') { transferDataId = fid; }
-      });
-      return (
-        rest({ path: `file/${clustersId}/download` })
-          .then(({ response }) => ({
-            mRNAFileId,
-            miRNAFileId,
-            transferDataId,
-            clusterData: response,
-            outputDirId: state.output_dir,
-            page2,
-            page2Elements,
-            page3,
-            page3Elements
-          }))
-      );
-    })
+    .then(({
+      output_mrna_heatmap: { fileId: mRNAFileId },
+      output_mirna_heatmap: { fileId: miRNAFileId },
+      clustersJSON: { data: clusterData },
+      transferData: { fileId: transferDataId }
+    }) => ({
+      mRNAFileId,
+      miRNAFileId,
+      transferDataId,
+      clusterData,
+      outputDirId: state.output_dir,
+      page2,
+      page2Elements,
+      page3,
+      page3Elements
+    }))
   );
 
   return (

--- a/web_client/analysis-modules/igpse2.jsx
+++ b/web_client/analysis-modules/igpse2.jsx
@@ -36,18 +36,12 @@ const actionProcess = (data, page) => {
   const runPromise = (
     analysisUtils.runTask(task, { inputs, outputs }, { title, maxPolls })
 
-    .then((files) => {
-      let dataPlotId;
-
-      files.forEach(({ fileId: fid, name }) => {
-        if (name === 'dataplot.png') { dataPlotId = fid; }
-      });
-
-      return {
-        survPlotId: dataPlotId,
-        ...priorData
-      };
-    })
+    .then(({
+      dataplot: { fileId: survPlotId }
+    }) => ({
+      survPlotId,
+      ...priorData
+    }))
   );
 
   return (

--- a/web_client/analysis-modules/kmeans.jsx
+++ b/web_client/analysis-modules/kmeans.jsx
@@ -30,17 +30,13 @@ const actionProcess = (data, page) => {
   const runPromise = (
     analysisUtils.runTask(task, { inputs, outputs }, { title, maxPolls })
 
-    .then((files) => {
-      let centersId;
-      let clustersId;
-
-      files.forEach(({ fileId: fid, name }) => {
-        if (name === 'centers.csv') { centersId = fid; }
-        if (name === 'clusters.csv') { clustersId = fid; }
-      });
-
-      return { centersId, clustersId };
-    })
+    .then(({
+      centers: { fileId: centersId },
+      clusters: { fileId: clustersId },
+    }) => ({
+      centersId,
+      clustersId
+    }))
   );
 
   return (

--- a/web_client/analysis-modules/silhouette.jsx
+++ b/web_client/analysis-modules/silhouette.jsx
@@ -36,22 +36,15 @@ const actionProcess = (data, page) => {
   const runPromise = (
     analysisUtils.runTask(task, { inputs, outputs }, { title, maxPolls })
 
-    .then((files) => {
-      let dataplot1Id;
-      let dataplot2Id;
-
-      files.forEach(({ fileId: fid, name }) => {
-        if (name === 'dataplot1.png') { dataplot1Id = fid; }
-        if (name === 'dataplot2.png') { dataplot2Id = fid; }
-      });
-
-      return {
-        dataplot1Id,
-        dataplot2Id,
-        page2,
-        page2Elements
-      };
-    })
+    .then(({
+      dataplot1: { fileId: dataplot1Id },
+      dataplot2: { fileId: dataplot2Id }
+    }) => ({
+      dataplot1Id,
+      dataplot2Id,
+      page2,
+      page2Elements
+    }))
   );
 
   return (

--- a/web_client/analysis-modules/silhouette2.jsx
+++ b/web_client/analysis-modules/silhouette2.jsx
@@ -8,8 +8,8 @@ const D = store.dispatch.bind(store);
 const main = (data) => {
   let promise = Promise.resolve();
 
-  data.page2Elements[0].elements[0].fileId = data.dataPlot1Id;
-  data.page2Elements[0].elements[1].fileId = data.dataPlot2Id;
+  data.page2Elements[0].elements[0].fileId = data.dataplot1Id;
+  data.page2Elements[0].elements[1].fileId = data.dataplot2Id;
 
   data.page2Elements.forEach((e) => (
     promise = promise.then(() => D(

--- a/web_client/analysis-modules/surv.jsx
+++ b/web_client/analysis-modules/surv.jsx
@@ -37,19 +37,17 @@ const actionProcess = (data, page) => {
   const runPromise = (
     analysisUtils.runTask(task, { inputs, outputs }, { title, maxPolls })
 
-    .then((files) => {
-      let fitId;
-      let sdfId;
-      let dataplotId;
-
-      files.forEach(({ fileId: fid, name }) => {
-        if (name === 'fit.rdata') { fitId = fid; }
-        if (name === 'sdf.rdata') { sdfId = fid; }
-        if (name === 'survivor-plot.png') { dataplotId = fid; }
-      });
-
-      return { fitId, sdfId, dataplotId, page2, survPlotElement };
-    })
+    .then(({
+      fit: { fileId: fitId },
+      sdf: { fileId: sdfId },
+      dataplot: { fileId: dataplotId }
+    }) => ({
+      fitId,
+      sdfId,
+      dataplotId,
+      page2,
+      page2Elements
+    }))
   );
 
   return (

--- a/web_client/analysis-modules/surv2.jsx
+++ b/web_client/analysis-modules/surv2.jsx
@@ -7,7 +7,7 @@ const D = store.dispatch.bind(store);
 const main = (data) => {
   let promise = Promise.resolve();
 
-  data.page2Elements[0].fileId = data.dataPlotId;
+  data.page2Elements[0].fileId = data.dataplotId;
 
   data.page2Elements.forEach((e) => (
     promise = promise.then(() => D(

--- a/web_client/utils/analysis.jsx
+++ b/web_client/utils/analysis.jsx
@@ -87,7 +87,7 @@ export const pollJob = (
 ) => (
   Promise.delay(pollInterval)
     .then(() => rest({ path: `osumo/results/${jobId}` }))
-    .then(({ response: { status, files } }) => {
+    .then(({ response: { status, results } }) => {
       if (status === 4) {  /* error */
         throw new Error(
           `OSUMO task "${title}" (${taskName}/${jobId})` +
@@ -98,7 +98,7 @@ export const pollJob = (
           `OSUMO task "${title}" (${taskName}/${jobId}) was canceled`
         );
       } else if (status === 3) {  /* success */
-        return files;
+        return results;
       }
 
       if (maxPolls > 0) {


### PR DESCRIPTION
Updates the document returned for osumo/results/:id to have a "results"
attribute instead of a "files" attribute.  The new results attribute now
maps output variable names to their computed results, with additional
data that lets clients pick out results that were written to girder from
inline results.  That also means that we don't have to turn *every*
result we want to use into a girder item, anymore!

Note that there's several moving parts needed to make this work on the
back end, including a plugin for girder-worker that's needed to work
around the disaster that is the current implementation of
girder-worker's mongodb IO mode. (Note: someone, probably me, should
really upstream a fix for it).  The aformentioned plugin lives in
github.com/osumo/sumo_io.