### PR TITLE
Anonymous login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ __pycache__
 ### PyCharm ###
 .idea/
 _build
-osumo_loginpass.txt
+osumo_anonlogin.txt

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 ### PyCharm ###
 .idea/
 _build
+osumo_loginpass.txt

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -12,7 +12,7 @@ from bson.objectid import ObjectId
 from girder import events, logprint
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.api.rest import Resource, RestException, setCurrentUser
+from girder.api.rest import Resource, RestException, setCurrentUser, getCurrentUser
 from girder.constants import AccessType, TokenScope
 from girder.utility.model_importer import ModelImporter
 from girder.utility.plugin_utilities import registerPluginWebroot
@@ -36,6 +36,7 @@ class Osumo(Resource):
         self.route('GET', ('ui', ':key'), self.getUISpecByKey)
         self.route('GET', ('ui',), self.getUISpecs)
         self.route('POST', ('anonlogin',), self.anonymousLogin)
+        self.route('GET', ('user', 'me'), self.getMe)
 
         self.anonuser = anonuser
         self.anonpassword = anonpassword
@@ -59,6 +60,16 @@ class Osumo(Resource):
             },
             'message': 'Anonymous login succeeded.'
         }
+
+    @describeRoute(
+        Description('Query for the currently logged in user, including a flag for whether this is the "anonymous user".')
+    )
+    @access.public
+    def getMe(self, params):
+        rawuser = getCurrentUser()
+        user = self.model('user').filter(rawuser, rawuser)
+        user['anonymous'] = user['login'] == self.anonuser
+        return user
 
     @describeRoute(
         Description('Return job status and list of output files.')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -454,7 +454,17 @@ def load(info):
     anonpassword = os.environ.get('OSUMO_ANON_PASSWORD')
 
     if not anonuser or not anonpassword:
-        logprint.error('Environment variables OSUMO_ANON_USER and OSUMO_ANON_PASSWORD must be set.')
+        try:
+            with open(os.path.join(info['pluginRootDir'], 'osumo_loginpass.txt')) as f:
+                parts = map(lambda x: x.strip(), f.read().split(' ', 1))
+                anonuser = parts[0]
+                if len(parts) > 1:
+                    anonpassword = parts[1]
+        except IOError:
+            pass
+
+    if not anonuser or not anonpassword:
+        logprint.error('Environment variables OSUMO_ANON_USER and OSUMO_ANON_PASSWORD must be set, or a file osumo_loginpass.txt must exist.')
         raise RuntimeError
 
     Osumo._cp_config['tools.staticdir.dir'] = (

--- a/web_client/actions.jsx
+++ b/web_client/actions.jsx
@@ -537,16 +537,15 @@ export const submitLoginForm = (form) => promiseAction(
       rest
         .logout()
         .then(() => rest.login(login, password))
+        .catch(({ responseJSON: { message }}) => (
+          dispatch(setDialogError('login', message))
+            .then(() => dispatch(loginAnonymousUser()))
+            .then(() => Promise.reject(new Error(message)))
+        ))
         .then((user) => dispatch(setCurrentUser(user, user.token.token)))
         .then((user) => (result = user))
         .then(() => dispatch(closeDialog()))
         .then(() => result)
-        .catch(
-          ({ responseJSON: { message } }) => (
-            dispatch(setDialogError('login', message))
-              .then(() => dispatch(loginAnonymousUser()))
-          )
-        )
     );
   }
 );

--- a/web_client/actions.jsx
+++ b/web_client/actions.jsx
@@ -535,7 +535,8 @@ export const submitLoginForm = (form) => promiseAction(
     let result;
     return (
       rest
-        .login(login, password)
+        .logout()
+        .then(() => rest.login(login, password))
         .then((user) => dispatch(setCurrentUser(user, user.token.token)))
         .then((user) => (result = user))
         .then(() => dispatch(closeDialog()))
@@ -543,6 +544,7 @@ export const submitLoginForm = (form) => promiseAction(
         .catch(
           ({ responseJSON: { message } }) => (
             dispatch(setDialogError('login', message))
+              .then(() => dispatch(loginAnonymousUser()))
           )
         )
     );

--- a/web_client/actions.jsx
+++ b/web_client/actions.jsx
@@ -119,6 +119,12 @@ export const addUploadFileEntries = (entries) => promiseAction(
   }
 );
 
+export const loginAnonymousUser = () => promiseAction(
+  // TODO: abstract these out of the code entirely.
+  (dispatch, getState) => rest.login('anonuser', 'anonpassword')
+    .then(user => dispatch(setCurrentUser(user, user.token.token, true)))
+);
+
 export const clearLoginInfo = () => promiseAction(
   (dispatch, getState) => {
     dispatch({ type: ACTION_TYPES.CLEAR_LOGIN_INFO });
@@ -426,9 +432,9 @@ export const setCurrentAnalysisPage = (page, key) => promiseAction(
   }
 );
 
-export const setCurrentUser = (user, token) => promiseAction(
+export const setCurrentUser = (user, token, anonymous=false) => promiseAction(
   (dispatch, getState) => {
-    dispatch({ type: ACTION_TYPES.SET_LOGIN_INFO, token, user });
+    dispatch({ type: ACTION_TYPES.SET_LOGIN_INFO, token, user, anonymous });
     return (
       dispatch(setFileNavigationRoot(user))
         .then(() => ({ ...getState().loginInfo.user }))
@@ -545,7 +551,7 @@ export const submitLoginForm = (form) => promiseAction(
 
 export const submitLogoutForm = () => promiseAction(
   (dispatch, getState) => (
-    rest.logout().then(() => dispatch(clearLoginInfo()))
+    rest.logout().then(() => dispatch(loginAnonymousUser()))
       .then(() => ({ ...getState().loginInfo }))
   )
 );
@@ -826,7 +832,7 @@ export const verifyCurrentUser = () => promiseAction(
               )
           )
 
-          : dispatch(clearLoginInfo())
+          : dispatch(loginAnonymousUser())
       ))
   )
 );
@@ -839,6 +845,7 @@ export default {
   closeDialog,
   disableAnalysisPage,
   enableAnalysisPage,
+  loginAnonymousUser,
   onItemSelect,
   openFileSelectorDialog,
   openLoginDialog,

--- a/web_client/actions.jsx
+++ b/web_client/actions.jsx
@@ -121,7 +121,7 @@ export const addUploadFileEntries = (entries) => promiseAction(
 
 export const loginAnonymousUser = () => promiseAction(
   // TODO: abstract these out of the code entirely.
-  (dispatch, getState) => rest.login('anonuser', 'anonpassword')
+  (dispatch, getState) => rest.anonLogin()
     .then(user => dispatch(setCurrentUser(user, user.token.token, true)))
 );
 

--- a/web_client/actions.jsx
+++ b/web_client/actions.jsx
@@ -828,9 +828,9 @@ export const verifyCurrentUser = () => promiseAction(
     rest({ path: 'token/current' })
       .then(({ response: currentToken }) => (
         currentToken
-          ? rest({ path: 'user/me' }).then(
+          ? rest({ path: 'osumo/user/me' }).then(
               ({ response: user }) => (
-                dispatch(setCurrentUser(user, currentToken._id))
+                dispatch(setCurrentUser(user, currentToken._id, user.anonymous))
               )
           )
 

--- a/web_client/actions.jsx
+++ b/web_client/actions.jsx
@@ -122,7 +122,7 @@ export const addUploadFileEntries = (entries) => promiseAction(
 export const loginAnonymousUser = () => promiseAction(
   // TODO: abstract these out of the code entirely.
   (dispatch, getState) => rest.anonLogin()
-    .then(user => dispatch(setCurrentUser(user, user.token.token, true)))
+    .then(({ response: user }) => dispatch(setCurrentUser(user.user, user.authToken.token, true)))
 );
 
 export const clearLoginInfo = () => promiseAction(

--- a/web_client/components/containers/header.jsx
+++ b/web_client/components/containers/header.jsx
@@ -5,9 +5,12 @@ import actions from '../../actions';
 
 const HeaderContainer = connect(
   ({
-    loginInfo: { user: currentUser },
+    loginInfo: {
+      user: currentUser,
+      anonymous
+    },
     header: { dropdownOpened }
-  }) => ({ currentUser, dropdownOpened }),
+  }) => ({ currentUser, dropdownOpened, anonymous }),
 
   (dispatch) => ({
     onDropdown: () => dispatch(actions.toggleHeaderDropdown()),

--- a/web_client/components/header/index.jsx
+++ b/web_client/components/header/index.jsx
@@ -4,6 +4,7 @@ import User from './user';
 class Header extends React.Component {
   render () {
     let {
+      anonymous,
       currentUser,
       dropdownOpened,
       onDropdown,
@@ -23,6 +24,7 @@ class Header extends React.Component {
           </div>
           <User
             currentUser={currentUser}
+            anonymous={anonymous}
             dropdownOpened={dropdownOpened}
             onDropdown={onDropdown}
             onFolders={onFolders}

--- a/web_client/components/header/user.jsx
+++ b/web_client/components/header/user.jsx
@@ -6,6 +6,7 @@ class User extends React.Component {
     let result;
     let {
       currentUser,
+      anonymous,
       dropdownOpened,
       onDropdown,
       onFolders,
@@ -16,7 +17,7 @@ class User extends React.Component {
     } = this.props;
 
     /* TODO(opadron): this should be broken down into further components. */
-    if (currentUser) {
+    if (currentUser && !anonymous) {
       let id = currentUser._id;
 
       onFolders = partial(onFolders, id);

--- a/web_client/globals.jsx
+++ b/web_client/globals.jsx
@@ -9,7 +9,7 @@ export const apiRoot = girderRest.apiRoot;
 import restRequests from './utils/rest-requests';
 import events from './utils/events';
 export const staticRoot = 'static';
-export const rest = restRequests({ events, apiRoot });
+export const rest = restRequests;
 
 import reducer from './reducer';
 
@@ -20,7 +20,7 @@ export const IN_PRODUCTION = (
 export const store = (
   IN_PRODUCTION
   ? createStore(reducer, applyMiddleware(thunk))
-  : createStore(reducer, applyMiddleware(thunk, createLogger()))
+  : createStore(reducer, applyMiddleware(thunk, createLogger({ diff: true })))
 );
 
 import Promise from 'bluebird';

--- a/web_client/globals.jsx
+++ b/web_client/globals.jsx
@@ -20,7 +20,10 @@ export const IN_PRODUCTION = (
 export const store = (
   IN_PRODUCTION
   ? createStore(reducer, applyMiddleware(thunk))
-  : createStore(reducer, applyMiddleware(thunk, createLogger({ diff: true })))
+  : createStore(reducer, applyMiddleware(thunk, createLogger({
+    diff: true,
+    collapsed: () => true
+  })))
 );
 
 import Promise from 'bluebird';

--- a/web_client/reducer/dialog.jsx
+++ b/web_client/reducer/dialog.jsx
@@ -134,8 +134,7 @@ const dialog = (state = {}, action) => {
     type === ACTION_TYPES.OPEN_FILE_SELECTOR_DIALOG ||
     type === ACTION_TYPES.OPEN_LOGIN_DIALOG ||
     type === ACTION_TYPES.OPEN_RESET_PASSWORD_DIALOG ||
-    type === ACTION_TYPES.OPEN_REGISTER_DIALOG ||
-    type === ACTION_TYPES.SET_LOGIN_INFO
+    type === ACTION_TYPES.OPEN_REGISTER_DIALOG
   ) {
     state = (
       setDialogComponent(

--- a/web_client/reducer/login-info.jsx
+++ b/web_client/reducer/login-info.jsx
@@ -3,24 +3,30 @@ import ACTION_TYPES from './action-types';
 
 const ensure = (x, def) => (isNil(x) ? def : x);
 
-const setLoginInfo = (loginInfo, user, token) => {
+const setLoginInfo = (loginInfo, user, token, anonymous=false) => {
   token = ensure(token, (user ? user.token : undefined));
 
-  if (loginInfo.user !== user || loginInfo.token !== token) {
-    loginInfo = { ...loginInfo, token, user };
+  if (loginInfo.user !== user || loginInfo.token !== token || loginInfo.anonymous !== anonymous) {
+    loginInfo = { ...loginInfo, token, user, anonymous };
   }
 
   return loginInfo;
 };
 
-const loginInfo = (state = {}, action) => {
+const initialState = {
+  user: null,
+  token: null,
+  anonymous: false
+};
+
+const loginInfo = (state = initialState, action) => {
   const { type } = action;
 
   if (type === ACTION_TYPES.CLEAR_LOGIN_INFO) {
     state = setLoginInfo(state, null);
   } else if (type === ACTION_TYPES.SET_LOGIN_INFO) {
-    const { token, user } = action;
-    state = setLoginInfo(state, user, token);
+    const { token, user, anonymous } = action;
+    state = setLoginInfo(state, user, token, anonymous);
   }
 
   return state;

--- a/web_client/utils/rest-requests.jsx
+++ b/web_client/utils/rest-requests.jsx
@@ -1,178 +1,24 @@
+import { restRequest } from 'girder/rest';
+import { login, logout } from 'girder/auth';
+import { Promise } from './promise';
 import { search as searchCookies } from './cookie';
 import ajax from './ajax';
 
-const restRequests = ({
-  events,
-  apiRoot
-}) => {
-  /**
-   * Make a request to the REST API. Bind a 'done' handler to the return
-   * value that will be called when the response is successful. To bind a
-   * custom error handler, bind an 'error' handler to the return promise,
-   * which will be executed in addition to the normal behavior of logging
-   * the error to the console. To override the default error handling
-   * behavior, pass an 'error' key in your opts object; this should be done
-   * any time the server might throw an exception from validating user input,
-   * e.g. logging in, registering, or generally filling out forms.
-   *
-   * @param path The resource path, e.g. 'user/login'
-   * @param data The form parameter object.
-   * @param [type='GET'] The HTTP method to invoke.
-   * @param [girderToken] An alternative auth token to use for this request.
-   */
-  let result = (opts) => {
-    opts = opts || {};
-    let defaults = { dataType: 'json', type: 'GET' };
-    if (opts.path.substring(0, 1) !== '/') {
-      opts.path = '/' + opts.path;
-    }
-    opts.url = apiRoot + opts.path;
-
-    opts = Object.assign({}, defaults, opts);
-
-    var token = opts.girderToken || result.currentToken ||
-      searchCookies('girderToken');
-
-    if (token) {
-      opts.headers = opts.headers || {};
-      opts.headers['Girder-Token'] = token;
-    }
-    let ajaxObj = (
-      ajax(opts)
-      .catch(({ jqXHR: error, textStatus: status }) => {
-        let info;
-        if (error.status === 401) {
-          events.trigger('g:loginUi');
-          info = {
-            text: 'You must log in to view this resource',
-            type: 'warning',
-            timeout: 4000,
-            icon: 'info'
-          };
-        } else if (error.status === 403) {
-          info = {
-            text: 'Access denied. See the console for more details.',
-            type: 'danger',
-            timeout: 5000,
-            icon: 'attention'
-          };
-        } else if (error.status === 0 && error.statusText === 'abort') {
-          /* We expected this abort, so do nothing. */
-          return;
-        } else if (error.status === 500 && error.responseJSON &&
-                   error.responseJSON.type === 'girder') {
-          info = {
-            text: error.responseJSON.message,
-            type: 'warning',
-            timeout: 5000,
-            icon: 'info'
-          };
-        } else if (status === 'parsererror') {
-          info = {
-            text: 'A parser error occurred while communicating with the ' +
-              'server (did you use the correct value for `dataType`?). ' +
-                'Details have been logged in the console.',
-            type: 'danger',
-            timeout: 5000,
-            icon: 'attention'
-          };
-        } else {
-          info = {
-            text: 'An error occurred while communicating with the ' +
-              'server. Details have been logged in the console.',
-            type: 'danger',
-            timeout: 5000,
-            icon: 'attention'
-          };
-        }
-        events.trigger('g:alert', info);
-        return error;
-      })
-    );
-
-    ajaxObj.abort = function () {
-      if (this.isCancellable()) {
-        this.cancel();
-      }
-    };
-    return ajaxObj;
-  };
-
-  Object.assign(result, {
-    /**
-     * Log in to the server. If successful, sets the value of
-     * girder.currentUser and girder.currentToken and triggers the 'g:login'
-     * and 'g:login.success'.  On failure, triggers the 'g:login.error'
-     * event.
-     *
-     * @param username The username or email to login as.
-     * @param password The password to use.
-     * @param cors If the girder server is on a different origin, set this
-     *        to 'true' to save the auth cookie on the current domain.
-     *        Alternatively, you may set the global option
-     *        'girder.corsAuth = true'.
-     */
-    login (username, password, cors) {
-      var auth = 'Basic ' + window.btoa(username + ':' + password);
-      if (cors === undefined) {
-        cors = result.corsAuth;
-      }
-
-      return result({
-        method: 'GET',
-        path: '/user/authentication',
-        headers: {
-          'Girder-Authorization': auth
-        }
-      }).then(({ response }) => {
-        response.user.token = response.authToken;
-
-        result.currentUser = response.user;
-        result.currentToken = response.user.token.token;
-
-        if (cors && !searchCookies('girderToken')) {
-          // For cross-origin requests, we should write the token into
-          // this document's cookie also.
-          document.cookie = 'girderToken=' + result.currentToken;
-        }
-
-        events.trigger('g:login.success', response.user);
-        events.trigger('g:login', response);
-
-        return response.user;
-      }).catch((jqXHR) => {
-        events.trigger('g:login.error', jqXHR.status, jqXHR);
-        return jqXHR;
-      });
-    },
-
-    logout () {
-      return result({
-        method: 'DELETE',
-        path: '/user/authentication'
-      }).then(() => {
-        result.currentUser = null;
-        result.currentToken = null;
-
-        events.trigger('g:login', null);
-        events.trigger('g:logout.success');
-      }).catch((jqXHR) => {
-        events.trigger('g:logout.error', jqXHR.status, jqXHR);
-        return jqXHR;
-      });
-    },
-
-    fetchCurrentUser () {
-      return result({
-        method: 'GET',
-        path: '/user/me'
-      }).then(({ response }) => response);
-    },
-
-    restRequest: result
+const restRequests = (...args) => {
+  const wrap = (response, status, jqXHR) => ({
+    response,
+    status,
+    jqXHR
   });
+  return new Promise((resolve, reject) => restRequest(...args).then((...a) => resolve(wrap(...a)), reject));
+};
 
-  return result;
+restRequests.login = (...args) => {
+  return new Promise((resolve, reject) => login(...args).then(resolve, reject));
+};
+
+restRequests.logout = (...args) => {
+  return new Promise((resolve, reject) => logout(...args).then(resolve, reject));
 };
 
 export default restRequests;

--- a/web_client/utils/rest-requests.jsx
+++ b/web_client/utils/rest-requests.jsx
@@ -17,6 +17,11 @@ restRequests.login = (...args) => {
   return new Promise((resolve, reject) => login(...args).then(resolve, reject));
 };
 
+restRequests.anonLogin = () => restRequests({
+  path: 'osumo/anonlogin',
+  method: 'POST'
+});
+
 restRequests.logout = (...args) => {
   return new Promise((resolve, reject) => logout(...args).then(resolve, reject));
 };

--- a/webpack.helper.js
+++ b/webpack.helper.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = function (cfg, pluginBuildData) {
-  cfg.watch = true;
   cfg.watchOptions = {
     poll: 1000
   };

--- a/webpack.helper.js
+++ b/webpack.helper.js
@@ -1,6 +1,11 @@
 'use strict';
 
 module.exports = function (cfg, pluginBuildData) {
+  cfg.watch = true;
+  cfg.watchOptions = {
+    poll: 1000
+  };
+
   cfg.module.loaders.push({
     test: /\.jsx?$/,
     exclude: /(node_modules|bower_components)/,


### PR DESCRIPTION
This adds the "anonymous login" functionality. Essentially:
- Any time you log out of the app explicitly, the system implicitly logs in a special user, but makes the UI look like no one is logged in. This lets people use the application without first having to create an account.
- The username can be supplied via an environment variable `OSUMO_ANON_USER` at Girder launch time, or via a file in the plugin root directory named `osumo_anonlogin.txt`, which should just contain one line of text with the username. Failing to supply these results in a fatal error, and the osumo plugin will not load.
- No password is required for the anonymous user account. Normal logins via the authentication subsystem are not possible. The way to become this user is to hit the `POST /osumo/anonlogin` endpoint.
- The plugin will create the anonymous user if it does not already exist.