### PR TITLE
add server-side handling of scratch spaces

### DIFF
--- a/web_client/utils/analysis.jsx
+++ b/web_client/utils/analysis.jsx
@@ -142,7 +142,7 @@ export const runTask = (taskName, params, options = {}) => {
   );
 
   return rest({ path, type: 'POST', data })
-    .then(({ response }) => response)
+    .then((result) => result.response)
     .then(({
       job: { _id: id },
       folder

--- a/web_client/utils/analysis.jsx
+++ b/web_client/utils/analysis.jsx
@@ -141,14 +141,15 @@ export const runTask = (taskName, params, options = {}) => {
       .reduce(objectReduce, {})
   );
 
-  return (
-    rest({ path, type: 'POST', data })
-      .then(({
-        response: {
-          job: { _id: id }
-        }
-      }) => pollJob(id, title, taskName, pollInterval, 0, maxPolls))
-  );
+  return rest({ path, type: 'POST', data })
+    .then(({ response }) => response)
+    .then(({
+      job: { _id: id },
+      folder
+    }) => {
+      return pollJob(id, title, taskName, pollInterval, 0, maxPolls)
+        .then((data) => ({ ...data, folder }));
+    });
 };
 
 export const traverseAnalysisElements = (obj, visitor) => {


### PR DESCRIPTION
(To be rebased after #56 is merged).

Adds server-side handling of scratch spaces.  Now,
every job created through OSUMO will have a
dedicated folder created for its outputs.  This
logic was moved server-side so that the directory
could be created after the job entry was created
(so that we know what id to use), but before
populating the job entry with the girder_io
entries for any specified outputs (that would use
the created folder).  Only the server can address
this chicken-and-egg issue.

Explicitly-specified destination folders are
silently ignored for backwards compatibility.
There are more changes that should be made to the
client to take advantage of the new server-side
feature/eliminate the need for the
silently-ignored parent parameters, but I stop
here to keep the code changes minimal; this PR
should represent the near-minimum changes required
to work around the issue mentioned in #56.