### PR TITLE
fix several issues preventing full end-to-end functionality

### DIFF
--- a/server/task_specs/feature-apply.py
+++ b/server/task_specs/feature-apply.py
@@ -1,5 +1,6 @@
 """Apply a previously-computed feature matching to the given data sets."""
 
+import csv
 import json
 
 # include<lib/csv.py>
@@ -18,8 +19,8 @@ def main(
     dialect_1 = get_dialect(input_path_1)
     dialect_2 = get_dialect(input_path_2)
 
-    data1, rows1, columns1 = read_csv(input_path_1, dialect_1)
-    data2, rows2, columns2 = read_csv(input_path_2, dialect_2)
+    data1, rows1, columns1, corner1 = read_csv(input_path_1, dialect_1)
+    data2, rows2, columns2, corner2 = read_csv(input_path_2, dialect_2)
 
     try:
         match_results = json.loads(match_input_path)
@@ -53,8 +54,8 @@ def main(
     new_cols2 = columns2[index2]
     new_data2 = data2[:, index2]
 
-    write_csv(new_data1, rows1, new_cols1, output_path_1, dialect_1)
-    write_csv(new_data2, rows2, new_cols2, output_path_2, dialect_2)
+    write_csv(new_data1, rows1, new_cols1, corner1, output_path_1, csv.excel)
+    write_csv(new_data2, rows2, new_cols2, corner2, output_path_2, csv.excel)
 
 output_path_1 = 'output_1.csv'
 output_path_2 = 'output_2.csv'

--- a/server/task_specs/feature-slice.py
+++ b/server/task_specs/feature-slice.py
@@ -26,16 +26,13 @@ with open(input_path, 'rU') as input_f:
         output_f = open(sliced_output, 'w', newline='')
 
     with output_f:
-        writer = csv.writer(output_f, dialect=dialect)
+        writer = csv.writer(output_f, dialect=csv.excel)
 
         if slice_columns:
             indexes = []
             columns = next(reader)
 
             for (index, column) in enumerate(columns):
-                if index == 0:
-                    continue
-
                 if index == 0 or column in selections:
                     indexes.append(index)
 

--- a/server/task_specs/igpse-preprocess.py
+++ b/server/task_specs/igpse-preprocess.py
@@ -1,0 +1,73 @@
+"""Remove columns with missing/invalid data."""
+
+import csv
+import math
+
+# include<lib/csv.py>
+
+# ifdef<LINTING>
+from included_files import get_dialect, read_csv, write_csv
+from girder_worker_environment import input_path_1, input_path_2
+# endif
+
+dialect_1 = get_dialect(input_path_1)
+dialect_2 = get_dialect(input_path_2)
+
+data1, rows1, columns1, corner = read_csv(input_path_1, dialect_1)
+data2, rows2, columns2, corner = read_csv(input_path_2, dialect_2)
+
+invalid_indexes = set()
+
+n_columns1 = len(columns1)
+n_columns2 = len(columns2)
+
+for column_index in range(max(n_columns1, n_columns2)):
+    is_invalid = False
+
+    if column_index < n_columns1:
+        for row_index in range(len(rows1)):
+            is_invalid = (
+                math.isinf(data1[row_index][column_index]) or
+                math.isnan(data1[row_index][column_index]))
+
+            if is_invalid:
+                break
+
+    if not is_invalid and column_index < n_columns2:
+        for row_index in range(len(rows2)):
+            is_invalid = (
+                math.isinf(data2[row_index][column_index]) or
+                math.isnan(data2[row_index][column_index]))
+
+            if is_invalid:
+                break
+
+    if is_invalid:
+        invalid_indexes.add(column_index)
+
+if invalid_indexes:
+    data1 = [[
+        x for (i, x) in enumerate(row)
+        if i not in invalid_indexes
+    ] for row in data1]
+
+    data2 = [[
+        x for (i, x) in enumerate(row)
+        if i not in invalid_indexes
+    ] for row in data2]
+
+    columns1 = [x for (i, x) in enumerate(columns1)
+                if i not in invalid_indexes]
+
+    columns2 = [x for (i, x) in enumerate(columns2)
+                if i not in invalid_indexes]
+
+    output_path_1 = 'output_1.csv'
+    output_path_2 = 'output_2.csv'
+
+    write_csv(data1, rows1, columns1, corner, output_path_1, csv.excel)
+    write_csv(data2, rows2, columns2, corner, output_path_2, csv.excel)
+else:
+    # if nothing to remove, then this script is a no-op
+    output_path_1 = input_path_1
+    output_path_2 = input_path_2

--- a/server/task_specs/igpse-preprocess.yml
+++ b/server/task_specs/igpse-preprocess.yml
@@ -1,0 +1,28 @@
+---
+
+name: igpse-preprocess
+mode: python
+
+script: "#include<igpse-preprocess.py>"
+
+inputs:
+  - name: input_path_1
+    type: string
+    target: filepath
+    format: text
+
+  - name: input_path_2
+    type: string
+    target: filepath
+    format: text
+
+outputs:
+  - name: output_path_1
+    type: string
+    target: filepath
+    format: text
+
+  - name: output_path_2
+    type: string
+    target: filepath
+    format: text

--- a/server/task_specs/lib/csv.py
+++ b/server/task_specs/lib/csv.py
@@ -138,9 +138,10 @@ def make_float(x):
 def read_csv(input_path, dialect):
     """Perform a bulk read of the given csv file.
 
-    Performs a bulk read of the given csv file.  Returns a (data, rows, columns)
-    tuple where data is the 2D array matrix of the numeric data (list of rows),
-    rows is the list of row headers, and columns is the list of column headers.
+    Performs a bulk read of the given csv file.  Returns a (data, rows, columns,
+    corner) tuple where data is the 2D array matrix of the numeric data (list of
+    rows), rows is the list of row headers, columns is the list of column
+    headers, and corner is the column header value for the row headers.
     """
     from csv import reader
     from numpy import array, float64
@@ -148,7 +149,8 @@ def read_csv(input_path, dialect):
     row_headers, column_headers, data_block = None, None, None
     with open(input_path, 'rU') as f:
         reader = reader(f, dialect=dialect)
-        column_headers = list(next(reader))[1:]
+        column_headers = list(next(reader))
+        corner, column_headers = column_headers[0], column_headers[1:]
         row_headers, data_block = zip(
             *(
                 [row[0], row[1:]]
@@ -168,27 +170,29 @@ def read_csv(input_path, dialect):
             dtype=float64
         )
 
-    return data_block, row_headers, column_headers
+    return data_block, row_headers, column_headers, corner
 
 
-def write_csv_helper(data_block, row_headers, column_headers, f, dialect):
+def write_csv_helper(data_block, row_headers, column_headers,
+                     corner, f, dialect):
     """Internal csv writing helper."""
     from csv import writer
 
     writer = writer(f, dialect=dialect)
-    writer.writerow([''] + list(column_headers))
+    writer.writerow([corner] + list(column_headers))
     for row in zip(row_headers, data_block):
         writer.writerow([row[0]] + list(row[1]))
 
 
-def write_csv(data_block, row_headers, column_headers, output_path, dialect):
+def write_csv(data_block, row_headers, column_headers,
+              corner, output_path, dialect):
     """Perform a bulk write of the given data into a csv file."""
     from six import PY2
     if PY2:
         with open(output_path, 'wb') as f:
             write_csv_helper(
-                data_block, row_headers, column_headers, f, dialect)
+                data_block, row_headers, column_headers, corner, f, dialect)
     else:
         with open(output_path, 'w', newline='') as f:
             write_csv_helper(
-                data_block, row_headers, column_headers, f, dialect)
+                data_block, row_headers, column_headers, corner, f, dialect)

--- a/server/task_specs/strip-headers.py
+++ b/server/task_specs/strip-headers.py
@@ -1,0 +1,39 @@
+"""Remove headers from columns & rows."""
+
+import csv
+from six import PY2
+from tempfile import NamedTemporaryFile
+
+# include<lib/csv.py>
+
+# ifdef<LINTING>
+from included_files import get_dialect
+from girder_worker_environment import input_path
+# endif
+
+dialect = get_dialect(input_path)
+
+with open(input_path, 'rU') as input_f:
+    reader = csv.reader(input_f, dialect)
+
+    output_f = None
+    if PY2:
+        output_f = NamedTemporaryFile(mode='wb', delete=False)
+    else:
+        output_f = NamedTemporaryFile(mode='w', newline='', delete=False)
+
+    output_path = output_f.name
+
+    with output_f:
+        writer = csv.writer(output_f, dialect=csv.excel)
+
+        # Unconditionally skip the first row and
+        # the first value in every subsequent row.
+
+        # next(reader)
+        writer.writerow([
+            'V{}'.format(index + 1)
+            for (index, _) in enumerate(next(reader)[1:])
+        ])
+        for row in reader:
+            writer.writerow(row[1:])

--- a/server/task_specs/strip-headers.yml
+++ b/server/task_specs/strip-headers.yml
@@ -1,0 +1,18 @@
+---
+
+name: strip-headers
+mode: python
+
+script: "#include<strip-headers.py>"
+
+inputs:
+  - name: input_path
+    type: string
+    target: filepath
+    format: text
+
+outputs:
+  - name: output_path
+    type: string
+    target: filepath
+    format: text


### PR DESCRIPTION
Fixes several issues that made it impossible to
succesfully upload data, match their columns, and
run the iGPSe workflow end-to-end.

 - Changed python task spec scripts that produce
   csv files.  Now, all such scripts will
   unconditionally produce csv files using the
   "excel" dialect.

 - Updated the write_csv and read_csv lib
   functions so that they properly handle the
   "corner" label, or the label for the first
   column and first row.

 - Added server task specs

   - igpse-preprocess: removes columns with
     invalid data.

   - strip-headers: removes the headers from the
     input and replaces it with column labels V1,
     V2, ... VN

 - Updated the iGPSe workflow to take advantage of
   the new server tasks, invoking them where
   necessary.