### PR TITLE
fix row extraction issue

### DIFF
--- a/server/task_specs/lib/csv.py
+++ b/server/task_specs/lib/csv.py
@@ -55,7 +55,9 @@ class RowExtractor(object):
     def next(self):
         """Return the next row in a csv file."""
         read_until(self.file, '\n')
-        field = read_until(self.file, self.dialect.delimiter)
+
+        field = read_until(self.file, self.dialect.delimiter)[:-1]
+
         if not field:
             raise StopIteration
 


### PR DESCRIPTION
Fixes an issue with the row extractor code that caused it to return substrings that were slightly off: they would carry a trailing delimiter (`"abc123,"`) or in other cases cut off the last character in a row label (`"abc12"`).