### PR TITLE
reload task-specs on every request

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -20,7 +20,7 @@ from girder.utility.model_importer import ModelImporter
 from girder.utility.plugin_utilities import registerPluginWebroot
 from girder.plugins.worker import utils as workerUtils
 
-from .task_specs import task_specs
+from .task_specs import get_task_spec, get_task_specs
 from .ui_specs import ui_specs
 
 RE_ARG_SPEC = re.compile(r'''([^\(]+)(\((.+)\))?''')
@@ -149,7 +149,7 @@ class Osumo(Resource):
                     task.get('key', k),
                     task
                 )
-                for k, task in task_specs.items()
+                for k, task in get_task_specs().items()
             )
             if a == key
         ]
@@ -205,7 +205,7 @@ class Osumo(Resource):
                     task,
                     task.get('mode', '').lower()
                 )
-                for key, task in task_specs.items()
+                for key, task in get_task_specs().items()
             )
             if (not name or a == name) and (not mode or d == mode)
         ]
@@ -259,7 +259,7 @@ class Osumo(Resource):
     )
     def runTaskSpec(self, key, params, **kwargs):
         """Create a job from the given task spec."""
-        task_spec = task_specs.get(key)
+        task_spec = get_task_spec(key)
         if task_spec is None:
             raise RestException('No task named %s.' % key)
 

--- a/server/task_specs/__init__.py
+++ b/server/task_specs/__init__.py
@@ -45,4 +45,5 @@ def get_task_specs():
         for file in file_list)
     return {
         key: get_task_spec(key)
-        for key in key_list}
+        for key in key_list
+    }

--- a/server/task_specs/__init__.py
+++ b/server/task_specs/__init__.py
@@ -24,17 +24,25 @@ import os.path
 from glob import iglob
 from .. import yaml_loader
 
-task_specs = {  # dictionary
 
-    # key
-    os.path.splitext(os.path.basename(spec_path))[0]:
-        # value
-        yaml_loader.load(spec_path)
+def get_task_spec(key):
+    """Return the task spec for the given key."""
+    task_spec_path = '.'.join((key, 'yml'))
+    task_spec_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), task_spec_path)
+    task_spec = yaml_loader.load(task_spec_path)
+    task_spec['key'] = key.lower()
 
-    # current_file_location/*.yml
-    for spec_path in iglob(os.path.join(
+    return task_spec
+
+
+def get_task_specs():
+    """Return the set of task specs available."""
+    file_list = iglob(os.path.join(
         os.path.dirname(os.path.abspath(__file__)), '*.yml'))
-}
-
-for key in task_specs:
-    task_specs[key]['key'] = key.lower()
+    key_list = (
+        os.path.basename(os.path.splitext(file)[0])
+        for file in file_list)
+    return {
+        key: get_task_spec(key)
+        for key in key_list}


### PR DESCRIPTION
Addresses a long-held development pet-peeve of mine: that changes to the server-side task specs required a full server restart to take effect.

This PR changes the server logic so that task specs are loaded on demand and on *every* request.  There is no caching, so changes are now immediately visible.  So far, this reloading doesn't seem to be a major performance issue, but we can bring back the old behavior for production situations if we later deem it necessary.