### PR TITLE
Girder item improvements

### DIFF
--- a/web_client/actions.jsx
+++ b/web_client/actions.jsx
@@ -2,6 +2,7 @@ import { isNil, isString, isUndefined } from 'lodash';
 import URI from 'urijs';
 
 import globals from './globals';
+import { OSUMO_TMP_DIR_NAME } from './constants';
 import { Promise } from './utils/promise';
 import ACTION_TYPES from './reducer/action-types';
 
@@ -258,7 +259,7 @@ export const ensureScratchDirectory = (() => {
   return (args) => {
     if (!singleton) {
       singleton = ensureUserDirectory({
-        name: '__osumo_tmp',
+        name: OSUMO_TMP_DIR_NAME,
         description: 'Temporary Staging Space',
         ...args
       });

--- a/web_client/analysis-modules/feature-matching-correction.jsx
+++ b/web_client/analysis-modules/feature-matching-correction.jsx
@@ -7,7 +7,6 @@ import { store } from '../globals';
 import loadModel from '../utils/load-model';
 
 import ItemModel from 'girder/models/ItemModel';
-import { formatSize } from 'girder/misc';
 
 const dispatch = store.dispatch.bind(store);
 
@@ -102,13 +101,7 @@ const applyMatch = (data, page) => {
           .then(() => Promise.mapSeries(
             items,
             (item) => dispatch(actions.addAnalysisElement(
-              {
-                type: 'girderItem',
-                downloadUrl: item.downloadUrl(),
-                inlineUrl: item.downloadUrl({ contentDisposition: 'inline' }),
-                name: item.name(),
-                size: formatSize(item.get('size'))
-              },
+              { type: 'girderItem', item },
               priorData.page2
             ))
           ))

--- a/web_client/components/body/analysis/element/girder-item.jsx
+++ b/web_client/components/body/analysis/element/girder-item.jsx
@@ -1,13 +1,169 @@
 import React from 'react';
+import { formatSize } from 'girder/misc';
 
 class GirderItem extends React.Component {
   render () {
     let {
-      downloadUrl,
-      inlineUrl,
-      name,
-      size
+      item,
+      onStateChange,
+      onItemSave,
+      state = {}
     } = this.props;
+
+    let {
+      doSelect = false,
+      value: nameText = '',
+      savedItem = null,
+      saving = false
+    } = state;
+
+    if (savedItem) {
+      item = savedItem;
+      saving = false;
+    }
+
+    let downloadUrl = item.downloadUrl();
+    let inlineUrl = item.downloadUrl({ contentDisposition: 'inline' });
+    let name = item.name();
+    let size = formatSize(item.get('size'));
+
+    const savingOn = (e) => {
+      e.preventDefault();
+      onStateChange({
+        doSelect: true,
+        value: name,
+        saving: true
+      });
+    };
+
+    const savingOff = (e) => {
+      e.preventDefault();
+      onStateChange({
+        value: '',
+        saving: false
+      });
+    };
+
+    const saveItem = (e) => {
+      e.preventDefault();
+      onItemSave(item, nameText);
+    };
+
+    if (saving) {
+      return (
+        <div
+          style={{
+            border: '1px solid lightgrey',
+            borderRadius: 5,
+            maxWidth: 300,
+            overflow: 'hidden',
+            padding: 3,
+            whitespace: 'nowrap'
+          }}
+        >
+          <div className='input-group'>
+            <div className='input-group-btn'>
+              <button
+                className='btn btn-danger'
+                onClick={savingOff}
+                style={{
+                  height: '1.5em',
+                  width: '1.5em',
+                  padding: 0,
+                  margin: 0
+                }}
+                type='button'
+              >
+                <span className='icon icon-cancel' />
+              </button>
+            </div>
+            <input
+              style={{
+                height: '1.5em',
+                paddingLeft: '0.25em',
+                margin: 0
+              }}
+              type='text'
+              className='form-control'
+              value={nameText}
+              ref={(input) => {
+                if (doSelect && input) {
+                  input.focus();
+                  input.select();
+                }
+              }}
+              onChange={(e) => {
+                onStateChange({
+                  doSelect: false,
+                  value: e.target.value
+                });
+              }}
+              onKeyPress={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  saveItem(e);
+                }
+              }}
+            />
+            <div className='input-group-btn'>
+              <button
+                className='btn btn-success'
+                onClick={(e) => {
+                  e.preventDefault();
+                  saveItem(e);
+                }}
+                style={{
+                  height: '1.5em',
+                  width: '1.5em',
+                  padding: 0,
+                  margin: 0
+                }}
+                type='button'
+              >
+                <span className='icon icon-ok' />
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    let saveButton = [];
+    if (savedItem) {
+      saveButton = [
+        <i
+          key='save-button'
+          className='icon-ok'
+          style={{
+            display: 'inline-block',
+            marginLeft: 4,
+            color: 'white',
+            background: 'green',
+            border: '1px solid green',
+            borderRadius: 5
+          }}
+        />
+      ];
+    } else {
+      saveButton = [
+        <a
+          key='save-button'
+          onClick={savingOn}
+          target='_blank'
+          title='Save to OSUMO'
+          rel='noopener noreferrer'
+          style={{
+            display: 'inline-block',
+            marginLeft: 4,
+            border: '1px solid',
+            borderRadius: 5
+          }}
+        >
+          <i className='icon-floppy' />
+        </a>
+      ];
+    }
 
     return (
       <div>
@@ -16,41 +172,56 @@ class GirderItem extends React.Component {
           style={{
             borderRadius: 5,
             padding: 3,
-            border: '1px solid lightgrey',
+            border: (
+              savedItem
+                ? '1px solid rgba(0, 128, 0, 0.5)'
+                : '1px solid lightgrey'
+            ),
             maxWidth: 300,
             overflow: 'hidden',
             whiteSpace: 'nowrap'
           }}
         >
-          <span className='g-item-list-link'>
-            <a
-              href={downloadUrl}
-              title='Download'
-              style={{
-                display: 'inline-block',
-                border: '1px solid',
-                borderRadius: 5
-              }}
-            >
-              <i className='icon-download' />
-            </a>
-            <a
-              href={inlineUrl}
-              target='_blank'
-              title='View in browser'
-              rel='noopener noreferrer'
-              style={{
-                display: 'inline-block',
-                marginLeft: 4,
-                border: '1px solid',
-                borderRadius: 5
-              }}
-            >
-              <i className='icon-eye' />
-            </a>
-            <i className='icon-doc-text-inv' />
-            {name}
-          </span>
+          <div
+            style={{
+              width: 225,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              margin: 0,
+              float: 'left'
+            }}
+          >
+            <span className='g-item-list-link'>
+              <a
+                href={downloadUrl}
+                title='Download'
+                style={{
+                  display: 'inline-block',
+                  border: '1px solid',
+                  borderRadius: 5
+                }}
+              >
+                <i className='icon-download' />
+              </a>
+              <a
+                href={inlineUrl}
+                target='_blank'
+                title='View in browser'
+                rel='noopener noreferrer'
+                style={{
+                  display: 'inline-block',
+                  marginLeft: 4,
+                  border: '1px solid',
+                  borderRadius: 5
+                }}
+              >
+                <i className='icon-eye' />
+              </a>
+              {saveButton}
+              <i className='icon-doc-text-inv' />
+              {name}
+            </span>
+          </div>
           <div
             className='g-item-size'
             style={{

--- a/web_client/components/body/analysis/element/index.jsx
+++ b/web_client/components/body/analysis/element/index.jsx
@@ -24,6 +24,7 @@ class Element extends React.Component {
       onAction,
       onChildFileSelect,
       onChildStateChange,
+      onItemSave,
       onFileSelect,
       onStateChange,
       ...props
@@ -153,7 +154,7 @@ class Element extends React.Component {
           <GirderItemElement
             key='result'
             onStateChange={onStateChange}
-            onFileSelect={onFileSelect}
+            onItemSave={onItemSave}
             state={state}
             children={children}
             {...props}

--- a/web_client/components/body/analysis/index.jsx
+++ b/web_client/components/body/analysis/index.jsx
@@ -13,6 +13,7 @@ class Analysis extends React.Component {
       onBaseAnalysis,
       onAction,
       onFileSelect,
+      onItemSave,
       onPageClick,
       onStateChange,
       objects,
@@ -54,6 +55,7 @@ class Analysis extends React.Component {
                 )
               }
               onFileSelect={onFileSelect}
+              onItemSave={onItemSave}
               onStateChange={onStateChange}
               key={page.id}
             />

--- a/web_client/components/body/analysis/page.jsx
+++ b/web_client/components/body/analysis/page.jsx
@@ -18,6 +18,7 @@ class Page extends React.Component {
       objects,
       onAction,
       onFileSelect,
+      onItemSave,
       onStateChange,
       states
     } = this.props;
@@ -92,6 +93,9 @@ class Page extends React.Component {
                       states={states}
                       onAction={onAction}
                       onFileSelect={() => onFileSelect(element)}
+                      onItemSave={
+                        (item, name) => onItemSave(item, name, element)
+                      }
                       onStateChange={(state) => onStateChange(element, state)}
                       onChildFileSelect={onFileSelect}
                       onChildStateChange={onStateChange}

--- a/web_client/components/containers/analysis.jsx
+++ b/web_client/components/containers/analysis.jsx
@@ -120,6 +120,10 @@ const AnalysisContainer = connect(
               ) {
                 result = false;
               }
+            } else if (item._modelType === 'folder') {
+              if (item.name === '__osumo_tmp') {
+                result = false;
+              }
             }
 
             return result;

--- a/web_client/components/containers/analysis.jsx
+++ b/web_client/components/containers/analysis.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import Analysis from '../body/analysis';
 import actions from '../../actions';
 import { rest } from '../../globals';
+import { OSUMO_TMP_DIR_NAME } from '../../constants';
 import objectReduce from '../../utils/object-reduce';
 import { Promise } from '../../utils/promise';
 import loadModel from '../../utils/load-model';
@@ -123,7 +124,7 @@ const AnalysisContainer = connect(
                 result = false;
               }
             } else if (item._modelType === 'folder') {
-              if (item.name === '__osumo_tmp') {
+              if (item.name === OSUMO_TMP_DIR_NAME) {
                 result = false;
               }
             }

--- a/web_client/constants.jsx
+++ b/web_client/constants.jsx
@@ -6,11 +6,14 @@ const COPYRIGHT = String.fromCharCode(169);
 const NBSP = String.fromCharCode(160);
 const TIMES = String.fromCharCode(215);
 
+const OSUMO_TMP_DIR_NAME = '__osumo_tmp';
+
 export {
   ABOUT_URL,
   BUG_URL,
   CONTACT_URL,
   COPYRIGHT,
   NBSP,
+  OSUMO_TMP_DIR_NAME,
   TIMES
 };


### PR DESCRIPTION
Improves the `girderItem` analysis element type by adding a "save to OSUMO" button.  This allows users to skip the download-and-reupload process and save intermediate results directly to their private space on OSUMO.

Right now, the feature matching workflow is the only one that uses the `girderItem` element, so you can run that workflow with any two CSV files, apply the intermediate match, and see the two new widgets appear near the bottom of the screen.  There will be a new button that looks like a floppy disk that you can click on to save the file to your private space on OSUMO.

(Also, updates the file selection dialog so that the hidden `__osumo_tmp` directory is *actually* hidden from the user.)